### PR TITLE
DIY pref.ini

### DIFF
--- a/base/pref.ini
+++ b/base/pref.ini
@@ -10,6 +10,8 @@ default_url=
 
 ;Exclude nodes which remarks match the following patterns. Supports regular expression.
 exclude_remarks=(到期|剩余流量|时间|官网|产品)
+;移出回国节点和国内节点 by csh
+;exclude_remarks=(CN|China|BackToChina|回国)
 ;exclude_remarks=(other rule)
 
 ;Only include nodes which remarks match the following patterns. Supports regular expression.
@@ -17,6 +19,7 @@ exclude_remarks=(到期|剩余流量|时间|官网|产品)
 
 ;Clash config base used by the generator, supports local files/URL
 clash_rule_base=simple_base.yml
+;clash_rule_base=ClashPro.yml
 
 ;Surge config base used by the generator, supports local files/URL
 surge_rule_base=surge.conf
@@ -34,13 +37,6 @@ proxy_subscription=NONE
 
 ;Append a proxy type string ([SS] [SSR] [VMess]) to node remark.
 append_proxy_type=false
-
-[node_pref]
-udp_flag=false
-tcp_fast_open_flag=false
-sort_flag=false
-skip_cert_verify_flag=false
-filter_deprecated_nodes=false
 
 ;Rename remarks with the following patterns. Supports regular expression.
 ;Format: Search_Pattern@Replace_Pattern
@@ -96,6 +92,13 @@ filter_deprecated_nodes=false
 ; times RE
 rename_node=\(?((x|X)?(\d+)(\.?\d+)?)((\s?倍率?)|(x|X))\)?@$1x
 
+[node_pref]
+udp_flag=false
+tcp_fast_open_flag=false
+sort_flag=false
+skip_cert_verify_flag=false
+filter_deprecated_nodes=false
+
 [managed_config]
 ;Append a '#!MANAGED-CONFIG' info to Surge configurations
 write_managed_config=true
@@ -112,6 +115,7 @@ remove_old_emoji=true
 
 ;Rule to add emojis. Supports regular expression.
 ;Format: Remark_Search_Pattern,emoji
+;其中，因为 VMESS 包含 ES 字符串，所以要想办法用 正则表达式 排除掉 西班牙|ES；另外，Free 包含 FR|法国.
 
 rule=(流量|时间|应急|过期|Bandwidth|expire),🏳️‍🌈
 rule=AC,🇦🇨
@@ -122,13 +126,16 @@ rule=BE,🇧🇪
 rule=(BR|Brazil|巴西|圣保罗),🇧🇷
 rule=(Canada|加拿大|蒙特利尔|温哥华|楓葉|枫叶),🇨🇦
 rule=(瑞士|苏黎世),🇨🇭
-rule=(CN|China|回国|中国|江苏|北京|上海|广州|深圳|杭州|徐州|青岛|宁波|镇江|back|TW|Taiwan|台湾|台北|台中|新北|彰化|CHT|新北|台|HINET),🇨🇳
+;rule=(CN|China|回国|中国|江苏|北京|上海|广州|深圳|杭州|徐州|青岛|宁波|镇江|back|TW|Taiwan|台湾|台北|台中|新北|彰化|CHT|新北|台|HINET),🇨🇳
+rule=(CN|China|回国|中国|江苏|北京|上海|广州|深圳|杭州|徐州|青岛|宁波|镇江|back),🇨🇳
 rule=(DE|Germany|德国|法兰克福|德),🇩🇪
 rule=丹麦,🇩🇰
-rule=ES,🇪🇸
+;排除掉节点中的 VMESS
+rule=((?<!(?i)vm)((?i)es)|西班牙),🇪🇸
 rule=EU,🇪🇺
 rule=(Finland|芬兰|赫尔辛基),🇫🇮
-rule=(FR|France|法国|巴黎),🇫🇷
+;排除掉 节点中的 free(忽略大小写)，即不匹配 free 
+rule=(((?i)FR)(?!(?i)EE)|France|法国|巴黎),🇫🇷
 rule=(UK|England|UnitedKingdom|英国|英|伦敦),🇬🇧
 rule=(HK|HongKong|香港|深港|沪港|呼港|HKT|HKBN|HGC|WTT|CMI|穗港|京港|港),🇭🇰
 rule=(Indonesia|印尼|印度尼西亚|雅加达),🇮🇩
@@ -148,6 +155,8 @@ rule=(沙特|迪拜),🇸🇦
 rule=(SE|Sweden),🇸🇪
 rule=(SG|Singapore|新加坡|狮城|沪新|京新|泉新|穗新|深新|杭新),🇸🇬
 rule=(TH|Thailand|泰国|曼谷),🇹🇭
+;如果是国行的苹果手机,不显示台湾国旗，可以将其合并到 🇨🇳
+rule=(TW|Taiwan|台湾|台北|台中|新北|彰化|CHT|新北|台|HINET),🇹🇼
 rule=(TR|Turkey|土耳其|伊斯坦布尔),🇹🇷
 rule=(US|America|UnitedStates|美国|美|京美|波特兰|达拉斯|俄勒冈|凤凰城|费利蒙|硅谷|拉斯维加斯|洛杉矶|圣何塞|圣克拉拉|西雅图|芝加哥|沪美),🇺🇲
 rule=(VN|越南),🇻🇳
@@ -187,6 +196,7 @@ surge_ruleset=🛑 全球拦截,rules/NobyDa/Surge/AdRule.list
 surge_ruleset=🛑 全球拦截,rules/ConnersHua/Surge/Ruleset/Hijacking.list
 ;surge_ruleset=🎥 NETFLIX,rules/ConnersHua/Surge/Ruleset/Media/Netflix.list
 surge_ruleset=🌍 国外媒体,rules/ConnersHua/Surge/Ruleset/GlobalMedia.list
+surge_ruleset=🗻 日本媒体,rules/ConnersHua/Surge/Ruleset/NihonMedia.list
 surge_ruleset=🌏 国内媒体,rules/lhie1/Surge3/AsianTV.list
 surge_ruleset=📲 电报信息,rules/ConnersHua/Surge/Ruleset/Telegram.list
 surge_ruleset=🔰 节点选择,rules/ConnersHua/Surge/Ruleset/Global.list
@@ -231,14 +241,19 @@ surge_ruleset=🐟 漏网之鱼,[]FINAL
 
 ;for Surge rulesets
 custom_proxy_group=🔰 节点选择`select`[]♻️ 自动选择`[]🎯 全球直连`.*
-custom_proxy_group=♻️ 自动选择`url-test`.*`http://www.gstatic.com/generate_204`300
-;custom_proxy_group=🎥 NETFLIX`select`[]🔰 节点选择`[]♻️ 自动选择`[]🎯 全球直连`.*
+;custom_proxy_group=♻️ 自动选择`url-test`.*`http://www.gstatic.com/generate_204`300
+custom_proxy_group=♻️ 自动选择`url-test`^(?!.*(BackToChina|China|回国|中国)).*$`http://www.gstatic.com/generate_204`300
+;custom_proxy_group=🔯 故障转移`fallback`.*`http://www.gstatic.com/generate_204`300
+;custom_proxy_group=🍀 负载均衡`load-balance`.*`http://www.gstatic.com/generate_204`300
+;custom_proxy_group=🎥 NETFLIX,rules/ConnersHua/Surge/Ruleset/Media/Netflix.list
+custom_proxy_group=🎥 NETFLIX`select`[]🔰 节点选择`[]♻️ 自动选择`[]🎯 全球直连`.*
 ;custom_proxy_group=⛔️ 广告拦截`select`[]🛑 全球拦截`[]🎯 全球直连`[]🔰 节点选择
 ;custom_proxy_group=🚫 运营劫持`select`[]🛑 全球拦截`[]🎯 全球直连`[]🔰 节点选择
 custom_proxy_group=🌍 国外媒体`select`[]🔰 节点选择`[]♻️ 自动选择`[]🎯 全球直连`.*
 custom_proxy_group=🌏 国内媒体`select`[]🎯 全球直连`(HGC|HKBN|PCCW|HKT|深台|彰化|新北|台|hk|港|tw)`[]🔰 节点选择
 custom_proxy_group=📲 电报信息`select`[]🔰 节点选择`.*`[]🎯 全球直连
 custom_proxy_group=🍎 苹果服务`select`[]🔰 节点选择`[]🎯 全球直连`[]♻️ 自动选择`.*
+custom_proxy_group=🗻 日本媒体`url-test`(日|JP)`http://www.gstatic.com/generate_204`300
 custom_proxy_group=🎯 全球直连`select`[]DIRECT
 custom_proxy_group=🛑 全球拦截`select`[]REJECT`[]DIRECT
 custom_proxy_group=🐟 漏网之鱼`select`[]🔰 节点选择`[]🎯 全球直连`[]♻️ 自动选择`.*


### PR DESCRIPTION
1、添加了一个 日本媒体规则，使得 日本媒体 自动走 日本 IP 节点。
2、节点的 国家匹配，增加了  ES 和 FR 的特殊正则匹配，不匹配 remark 名称中 含有的 VMESS 和 FREE 字符串。
3、自动选择去掉 China|回国节点，因为回国和国内节点速度快，不是用来进行代理的，需要从中除掉。